### PR TITLE
Add missing dask dependency and make minimum version numbers explicit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,19 +15,20 @@ build:
 requirements:
   build:
     - setuptools
-    - cython
+    - cython >=0.23
     - python
-    - six
+    - six >=1.4
     - numpy x.x
-    - scipy
+    - scipy >=0.9
   run:
     - python
-    - six
+    - six >=1.4
     - numpy x.x
-    - scipy
-    - matplotlib
-    - networkx
-    - pillow
+    - scipy >=0.9
+    - matplotlib >=1.1
+    - networkx >=1.8
+    - pillow >=1.7.8
+    - dask >=0.5
 
 test:
   imports:


### PR DESCRIPTION
scikit-image now has dask[array] >= 0.5 as a runtime dependency - without this, I've run into errors like:

```
In [1]: from pkg_resources import WorkingSet, Requirement

In [2]: w = WorkingSet()

In [3]: r = Requirement('scikit-image')

In [4]: w.resolve([r])
---------------------------------------------------------------------------
DistributionNotFound                      Traceback (most recent call last)
<ipython-input-4-5fc9dbd41de2> in <module>()
----> 1 w.resolve([r])

/home/tom/miniconda3/envs/test-stable-glue-3/lib/python3.6/site-packages/setuptools-27.2.0-py3.6.egg/pkg_resources/__init__.py in resolve(self, requirements, env, installer, replace_conflicting)
    852                     if dist is None:
    853                         requirers = required_by.get(req, None)
--> 854                         raise DistributionNotFound(req, requirers)
    855                 to_activate.append(dist)
    856             if dist not in req:

DistributionNotFound: The 'dask[array]>=0.5.0' distribution was not found and is required by scikit-image
```

when using setuptools to import modules that depend on scikit-image.

I've also added the minimum required versions while I was at it.