### PR TITLE
Add missing dask (bump build number)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 04ea833383e0b6ad5f65da21292c25e1
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Build number was not bumped in PR ( https://github.com/conda-forge/scikit-image-feedstock/pull/5 ). This bumps it, which should issue a new release.

cc @astrofrog @jni