### PR TITLE
Update dependency on dask to use only dask[array]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 77a636bdc08c7668a15951894548c527f0c8c5c2abc86cb850de17551af51e3e
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -32,7 +32,7 @@ requirements:
     - matplotlib >=1.3.1
     - networkx >=1.8
     - pillow >=2.1.0
-    - dask >=0.5
+    - dask[array] >=0.5
     - pywavelets >=0.4.0
     - imageio >=2.1.0
 


### PR DESCRIPTION
A user pointed out on gitter that the scikit-image package pulls in bokeh and s3fs. My guess is that setting dask as a dependency, rather than dask[array], is the culprit.