### PR TITLE
Clean up dependencies by using dask-core

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 77a636bdc08c7668a15951894548c527f0c8c5c2abc86cb850de17551af51e3e
 
 build:
-  number: 1
+  number: 2
   script:
     - export LDFLAGS="-headerpad_max_install_names"  # [osx]
     - python -m pip install --no-deps .
@@ -36,7 +36,8 @@ requirements:
     - matplotlib >=1.3.1
     - networkx >=1.8
     - pillow >=2.1.0
-    - dask >=0.5
+    - dask-core >=0.15
+    - toolz >=0.8.2
     - pywavelets >=0.4.0
     - imageio >=2.1.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - networkx >=1.8
     - pillow >=2.1.0
     - dask-core >=0.15
-    - toolz >=0.8.2
+    - toolz >=0.7.4
     - pywavelets >=0.4.0
     - imageio >=2.1.0
 


### PR DESCRIPTION
See discussion in #10.

@jakirkham can you check the NumPy deps? Not sure about the =1.12.x syntax. Will scikit-image be built against NumPy 1.13.1? Thanks!