### PR TITLE
Drop unneeded selector  [ci skip]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - pip
     - cython >=0.23
     - six >=1.7.3
-    - numpy 1.11.3  # [not (win32 and py36)]
+    - numpy 1.11.3
     - scipy >=0.17
     - numpydoc >=0.6
     - msinttypes  # [win and py<35]


### PR DESCRIPTION
This didn't do anything as we don't support Windows 32-bit any more. However it really shouldn't have been there either. Hence we drop this selector.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
