### PR TITLE
Remove test script in favour of running pytest directly

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,9 @@ test:
   imports:
     - skimage
   commands:
-    - MPLBACKEND=Agg pytest --pyargs skimage
+    - setx MPLBACKEND "Agg"  # [win]
+    - export MPLBACKEND=Agg  # [not win]
+    - pytest --pyargs skimage
 
 about:
   home: http://scikit-image.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,7 @@ test:
     - skimage
   commands:
     - setx MPLBACKEND "Agg"  # [win]
-    - export MPLBACKEND=Agg  # [linux]
-    - export MPLBACKEND=Template  # [osx]
+    - export MPLBACKEND=Agg  # [unix]
     - pytest --pyargs skimage
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 1
   script:
+    - rm -rf skimage/viewer/tests  # we don't depend on Qt
     - python -m pip install --no-deps --ignore-installed .
   entry_points:
     - skivi = skimage.scripts.skivi:main
@@ -51,7 +52,8 @@ test:
     - skimage
   commands:
     - setx MPLBACKEND "Agg"  # [win]
-    - export MPLBACKEND=Agg  # [not win]
+    - export MPLBACKEND=Agg  # [linux]
+    - export MPLBACKEND=Template  # [osx]
     - pytest --pyargs skimage
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,6 @@ source:
 build:
   number: 1
   script:
-    - rm -f skimage/run-hessian.py
-    - rm -rf skimage/viewer/tests  # we don't depend on Qt
     - python -m pip install --no-deps --ignore-installed .
   entry_points:
     - skivi = skimage.scripts.skivi:main
@@ -51,6 +49,8 @@ test:
     - pytest-cov
   imports:
     - skimage
+  commands:
+    - MPLBACKEND=Agg pytest --pyargs skimage
 
 about:
   home: http://scikit-image.org/

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,8 +1,0 @@
-import sys
-import matplotlib
-
-matplotlib.use('Agg')
-
-import skimage
-
-sys.exit(skimage.test(verbose=True))


### PR DESCRIPTION
Previously the result of pytest wasn't actually followed because it didn't raise an error. It simply RETURNED the wrong value.

- call the test with the pytest command
- Use an environment variable to set the matplotlib backend (in anticipation of matplotlib being removed as an explicit dependency)
- Build number kept as 1 because nothing actually changes in the installed files

Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged) <---- ???
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
