### PR TITLE
leave-maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,6 @@ extra:
     - ivoflipse
     - jakirkham
     - jni
-    - Korijn
     - msarahan
     - ocefpaf
     - soupault


### PR DESCRIPTION
I no longer wish to maintain conda packages, so I'm editing myself out of the maintainers in the recipes.