### PR TITLE
disable build isolation which causes problems for windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - pip
     - cython >=0.23
     - six >=1.7.3
-    - numpy 1.11.3
+    - numpy 1.11
     - scipy >=0.17
     - msinttypes  # [win and py<35]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,14 @@ source:
     - 3637_filter_out_deprecation_pending_warning.patch
 
 build:
-  number: 1002
+  number: 1003
   script:
     - rm -rf skimage/viewer/tests  # we don't depend on Qt
-    - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+    - "{{ PYTHON }} -m pip install . --disable-pip-version-check --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vvv"
+    # @conda-forge/python, try building this package yourself on windows using the line below
+    # you should notice that pip contacts pypi and fetches the dependencies from pypi.org
+    # but only on windows
+    # - "{{ PYTHON }} -m pip install . --disable-pip-version-check --no-deps --ignore-installed --no-cache-dir -vvv"
   entry_points:
     - skivi = skimage.scripts.skivi:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,11 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  # url: https://pypi.io/packages/source/s/scikit-image/scikit-image-{{ version }}.tar.gz
-  # sha256: 86a9b3b4f74f231e0a6bcfd3235dcf3f0118df25dac21201da5e064d681e2c50
-  url: https://github.com/scikit-image/scikit-image/archive/v{{ version }}.tar.gz
-  fn: scikit-image-{{ version }}.tar.gz
-  sha256: 8da6fb09aeefb757735c510650ac0072be3831fa76d9747285f3c6ea1e0c5a08
+  url: https://pypi.io/packages/source/s/scikit-image/scikit-image-{{ version }}.tar.gz
+  sha256: 86a9b3b4f74f231e0a6bcfd3235dcf3f0118df25dac21201da5e064d681e2c50
   patches:
     # https://github.com/scikit-image/scikit-image/pull/3558
     - 3558_dont_directly_call_test_fixtures.patch
@@ -39,7 +36,7 @@ requirements:
   host:
     - python
     - pip
-    - cython 0.28
+    - cython >=0.23.4,!=0.28.2,!=0.29.0
     - six >=1.7.3
     - numpy 1.11
     - scipy >=0.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/scikit-image/scikit-image-{{ version }}.tar.gz
-  sha256: 86a9b3b4f74f231e0a6bcfd3235dcf3f0118df25dac21201da5e064d681e2c50
+  # url: https://pypi.io/packages/source/s/scikit-image/scikit-image-{{ version }}.tar.gz
+  # sha256: 86a9b3b4f74f231e0a6bcfd3235dcf3f0118df25dac21201da5e064d681e2c50
+  url: https://github.com/scikit-image/scikit-image/archive/v{{ version }}.tar.gz
+  fn: scikit-image-{{ version }}.tar.gz
+  sha256: 8da6fb09aeefb757735c510650ac0072be3831fa76d9747285f3c6ea1e0c5a08
   patches:
     # https://github.com/scikit-image/scikit-image/pull/3558
     - 3558_dont_directly_call_test_fixtures.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
   host:
     - python
     - pip
-    - cython >=0.23,=0.28
+    - cython 0.28
     - six >=1.7.3
     - numpy 1.11
     - scipy >=0.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
   host:
     - python
     - pip
-    - cython >=0.23
+    - cython >=0.23,=0.28
     - six >=1.7.3
     - numpy 1.11
     - scipy >=0.17


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
