### PR TITLE
Fix scipy constraint and add pip check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   # sha256: 3b8414ccb9b524d0d507909e9a4d3843af6ca9919152199d380f2b21639abf17
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - skivi = skimage.scripts.skivi:main
 
@@ -40,7 +40,8 @@ requirements:
   run:
     - python
     - numpy
-    - scipy >=1.8
+    - scipy >=1.8,<1.9.2  # [py <= 39]
+    - scipy >=1.8  # [py > 39]
     - networkx >=2.8
     - pillow >=9.0.1
     - imageio >=2.4.1
@@ -110,9 +111,11 @@ test:
     - pytest-localserver
     # Include pooch to ensure full test coverage
     - pooch  # [not (ppc64le or aarch64)]
+    - pip
   imports:
     - skimage
   commands:
+    - pip check
     - setx MPLBACKEND "Agg"  # [win]
     - export MPLBACKEND=Agg  # [unix]
     # A warning in numpy that makes tests fail has been fixed in 0.18


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
A downstream package I work on is failing `pip check` for python 3.9 (and would be for python 3.8 if I were checking it) because of the missing constraint on `scipy` for python <= 3.9.